### PR TITLE
Option to ignore output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assert_cli"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Pascal Hertleif <killercup@gmail.com>"]
 repository = "https://github.com/killercup/assert_cli.git"
 homepage = "https://github.com/killercup/assert_cli"

--- a/Readme.md
+++ b/Readme.md
@@ -49,6 +49,14 @@ this will show a nice, colorful diff in your terminal, like this:
 +42
 ```
 
+If you'd prefer to not check the output:
+
+```rust
+#[macro_use] extern crate assert_cli;
+assert_cli::assert_cli("echo", &["42"]).unwrap();
+assert_cli!("echo", &["42"] => Success).unwrap();
+```
+
 ## License
 
 Licensed under either of

--- a/tests/macro.rs
+++ b/tests/macro.rs
@@ -10,13 +10,16 @@ fn test_helper(exit_code: i32, output: &str) -> Vec<String> {
 
 #[test]
 fn assert_success() {
+    assert_cli!("true", &[""] => Success).unwrap();
     assert_cli!("echo", &["42"] => Success, "42").unwrap();
     assert!(assert_cli!("echo", &["1"] => Success, "42").is_err());
 }
 
 #[test]
 fn assert_failure() {
+    assert_cli!("bash", &test_helper(66, "sorry, my bad") => Error).unwrap();
     assert_cli!("bash", &test_helper(66, "sorry, my bad") => Error, "sorry, my bad").unwrap();
+    assert_cli!("bash", &test_helper(42, "error no 42") => Error 42).unwrap();
     assert_cli!("bash", &test_helper(42, "error no 42") => Error 42, "error no 42").unwrap();
 
     assert!(assert_cli!("echo", &["good"] => Error, "").is_err());


### PR DESCRIPTION
Fixes #6. I was thinking about whether to implement it as interpreting an empty string as matching any output, but I can see how many situations might call for explicitly expecting a command not to output (such as when testing a quiet mode). Is this alright?

Also, I think fuzzy matching should be a new issue. It would be a much different of an implementation than #6.