### PR TITLE
Update version number in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ Just add it to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-assert_cli = "0.1.0"
+assert_cli = "0.2.2"
 ```
 
 ## Example


### PR DESCRIPTION
This one really got me. I spent half an hour researching if the Rust macro include system had changed somehow until realizing that I had installed a version of this library that didn't include the macro yet :relieved: