### PR TITLE
Add skeptic support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
     - libdw-dev
 after_success:
 - travis-cargo --only stable doc-upload
+- rm tests/skeptic.rs # "skip" skeptic doctests for coverage
 - travis-cargo coveralls --no-sudo
 notifications:
   email:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 documentation = "http://killercup.github.io/assert_cli/"
 description = "Test CLI Applications."
+build = "build.rs"
 
 [features]
 default = []
@@ -17,3 +18,9 @@ dev = ["clippy"]
 ansi_term = "0.6.3"
 difference = "0.4.0"
 clippy = {version = "0.0.23", optional = true}
+
+[build-dependencies]
+skeptic = "0.5"
+
+[dev-dependencies]
+skeptic = "0.5"

--- a/README.md
+++ b/README.md
@@ -24,22 +24,28 @@ Here's a trivial example:
 
 ```rust
 extern crate assert_cli;
-assert_cli::assert_cli_output("echo", &["42"], "42").unwrap();
+fn main() {
+  assert_cli::assert_cli_output("echo", &["42"], "42").unwrap();
+}
 ```
 
 Or if you'd rather use the macro:
 
 ```rust,ignore
 #[macro_use] extern crate assert_cli;
-assert_cli!("echo", &["42"] => Success, "42").unwrap();
-assert_cli!("black-box", &["--special"] => Error 42, "error no 42\n").unwrap()
+fn main() {
+  assert_cli!("echo", &["42"] => Success, "42").unwrap();
+  assert_cli!("black-box", &["--special"] => Error 42, "error no 42\n").unwrap()
+}
 ```
 
 And here is one that will fail:
 
 ```rust,should_panic
 extern crate assert_cli;
-assert_cli::assert_cli_output("echo", &["42"], "1337").unwrap();
+fn main() {
+  assert_cli::assert_cli_output("echo", &["42"], "1337").unwrap();
+}
 ```
 
 this will show a nice, colorful diff in your terminal, like this:
@@ -53,8 +59,10 @@ If you'd prefer to not check the output:
 
 ```rust
 #[macro_use] extern crate assert_cli;
-assert_cli::assert_cli("echo", &["42"]).unwrap();
-assert_cli!("echo", &["42"] => Success).unwrap();
+fn main() {
+  assert_cli::assert_cli("echo", &["42"]).unwrap();
+  assert_cli!("echo", &["42"] => Success).unwrap();
+}
 ```
 
 All exported functions and the macro return a `Result` containing the
@@ -62,9 +70,11 @@ All exported functions and the macro return a `Result` containing the
 
 ```rust
 #[macro_use] extern crate assert_cli;
-let output = assert_cli!("echo", &["Number 42"] => Success).unwrap();
-let stdout = std::str::from_utf8(&output.stdout).unwrap();
-assert!(stdout.contains("42"));
+fn main() {
+  let output = assert_cli!("echo", &["Number 42"] => Success).unwrap();
+  let stdout = std::str::from_utf8(&output.stdout).unwrap();
+  assert!(stdout.contains("42"));
+}
 ```
 
 ## License

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+extern crate skeptic;
+
+fn main() {
+    skeptic::generate_doc_tests(&["README.md"]);
+}

--- a/tests/skeptic.rs
+++ b/tests/skeptic.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));


### PR DESCRIPTION
This commit adds Readme testing using [skeptic](https://github.com/brson/rust-skeptic).

I applied some experiences from adding skeptic to other libraries, such as the .travis.yml change that prevents intermittent Travis timeouts.

Unfortunately because skeptic only allows a single interpolation position we need to decide whether we want to display examples like this:

```rust
extern crate assert_cli;
fn main() {
  assert_cli::assert_cli_output("echo", &["42"], "42").unwrap();
} 
```
or like this:
```rust
assert_cli::assert_cli_output("echo", &["42"], "42").unwrap();
```

Meaning that, afaiu, we can't include `extern crate` without adding `fn main`.