### PR TITLE
Reuse output assertions between stdout/stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Here's a trivial example:
 extern crate assert_cli;
 
 fn main() {
-    assert_cli::Assert::command(&["echo", "42"]).prints("42").unwrap();
+    assert_cli::Assert::command(&["echo", "42"]).stdout().contains("42").unwrap();
 }
 ```
 
@@ -31,7 +31,7 @@ Or if you'd rather use the macro, to save you some writing:
 #[macro_use] extern crate assert_cli;
 
 fn main() {
-    assert_cmd!(echo "42").prints("42").unwrap();
+    assert_cmd!(echo "42").stdout().contains("42").unwrap();
 }
 ```
 
@@ -45,21 +45,21 @@ fn main() {
     let test = assert_cmd!(ls "foo-bar-foo")
         .fails()
         .and()
-        .prints_error("foo-bar-foo")
+        .stderr().contains("foo-bar-foo")
         .execute();
     assert!(test.is_ok());
 }
 ```
 
 If you want to match the program's output _exactly_, you can use
-`prints_exactly`:
+`stdout().is`:
 
 ```rust,should_panic
 #[macro_use] extern crate assert_cli;
 
 fn main() {
     assert_cmd!(wc "README.md")
-        .prints_exactly("1337 README.md")
+        .stdout().is("1337 README.md")
         .unwrap();
 }
 ```

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -283,11 +283,12 @@ impl Assert {
     }
 }
 
+/// Assertions for command output.
 #[derive(Debug)]
 pub struct OutputAssertionBuilder {
-    pub assertion: Assert,
-    pub kind: OutputKind,
-    pub expected_result: bool,
+    assertion: Assert,
+    kind: OutputKind,
+    expected_result: bool,
 }
 
 impl OutputAssertionBuilder {

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -79,7 +79,7 @@ impl Assert {
     ///
     /// assert_cli::Assert::command(&["echo"])
     ///     .with_args(&["42"])
-    ///     .prints("42")
+    ///     .stdout().contains("42")
     ///     .unwrap();
     /// ```
     pub fn with_args(mut self, args: &[&str]) -> Self {
@@ -96,7 +96,7 @@ impl Assert {
     ///
     /// assert_cli::Assert::command(&["wc", "lib.rs"])
     ///     .current_dir(std::path::Path::new("src"))
-    ///     .prints("lib.rs")
+    ///     .stdout().contains("lib.rs")
     ///     .execute()
     ///     .unwrap();
     /// ```
@@ -113,7 +113,7 @@ impl Assert {
     /// extern crate assert_cli;
     ///
     /// assert_cli::Assert::command(&["echo", "42"])
-    ///     .prints("42")
+    ///     .stdout().contains("42")
     ///     .unwrap();
     /// ```
     pub fn and(self) -> Self {
@@ -149,7 +149,7 @@ impl Assert {
     /// assert_cli::Assert::command(&["cat", "non-existing-file"])
     ///     .fails()
     ///     .and()
-    ///     .prints_error("non-existing-file")
+    ///     .stderr().contains("non-existing-file")
     ///     .unwrap();
     /// ```
     pub fn fails(mut self) -> Self {
@@ -167,7 +167,7 @@ impl Assert {
     /// assert_cli::Assert::command(&["cat", "non-existing-file"])
     ///     .fails_with(1)
     ///     .and()
-    ///     .prints_error_exactly("cat: non-existing-file: No such file or directory")
+    ///     .stderr().is("cat: non-existing-file: No such file or directory")
     ///     .unwrap();
     /// ```
     pub fn fails_with(mut self, expect_exit_code: i32) -> Self {
@@ -176,7 +176,7 @@ impl Assert {
         self
     }
 
-    /// Expect the command's output to **contain** `output`.
+    /// Create an assertion for stdout's contents
     ///
     /// # Examples
     ///
@@ -184,64 +184,18 @@ impl Assert {
     /// extern crate assert_cli;
     ///
     /// assert_cli::Assert::command(&["echo", "42"])
-    ///     .prints("42")
+    ///     .stdout().contains("42")
     ///     .unwrap();
     /// ```
-    pub fn prints<O: Into<String>>(mut self, output: O) -> Self {
-        self.expect_output.push(OutputAssertion {
-            expect: output.into(),
-            fuzzy: true,
-            expected_result: true,
+    pub fn stdout(self) -> OutputAssertionBuilder {
+        OutputAssertionBuilder {
+            assertion: self,
             kind: OutputKind::StdOut,
-        });
-        self
-    }
-
-    /// Expect the command to output **exactly** this `output`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// extern crate assert_cli;
-    ///
-    /// assert_cli::Assert::command(&["echo", "42"])
-    ///     .prints_exactly("42")
-    ///     .unwrap();
-    /// ```
-    pub fn prints_exactly<O: Into<String>>(mut self, output: O) -> Self {
-        self.expect_output.push(OutputAssertion {
-            expect: output.into(),
-            fuzzy: false,
             expected_result: true,
-            kind: OutputKind::StdOut,
-        });
-        self
+        }
     }
 
-    /// Expect the command's stderr output to **contain** `output`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// extern crate assert_cli;
-    ///
-    /// assert_cli::Assert::command(&["cat", "non-existing-file"])
-    ///     .fails()
-    ///     .and()
-    ///     .prints_error("non-existing-file")
-    ///     .unwrap();
-    /// ```
-    pub fn prints_error<O: Into<String>>(mut self, output: O) -> Self {
-        self.expect_output.push(OutputAssertion {
-            expect: output.into(),
-            fuzzy: true,
-            expected_result: true,
-            kind: OutputKind::StdErr,
-        });
-        self
-    }
-
-    /// Expect the command to output **exactly** this `output` to stderr.
+    /// Create an assertion for stdout's contents
     ///
     /// # Examples
     ///
@@ -251,109 +205,15 @@ impl Assert {
     /// assert_cli::Assert::command(&["cat", "non-existing-file"])
     ///     .fails_with(1)
     ///     .and()
-    ///     .prints_error_exactly("cat: non-existing-file: No such file or directory")
+    ///     .stderr().is("cat: non-existing-file: No such file or directory")
     ///     .unwrap();
     /// ```
-    pub fn prints_error_exactly<O: Into<String>>(mut self, output: O) -> Self {
-        self.expect_output.push(OutputAssertion {
-            expect: output.into(),
-            fuzzy: false,
+    pub fn stderr(self) -> OutputAssertionBuilder {
+        OutputAssertionBuilder {
+            assertion: self,
+            kind: OutputKind::StdErr,
             expected_result: true,
-            kind: OutputKind::StdErr,
-        });
-        self
-    }
-
-    /// Expect the command's output to not **contain** `output`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// extern crate assert_cli;
-    ///
-    /// assert_cli::Assert::command(&["echo", "42"])
-    ///     .doesnt_print("73")
-    ///     .execute()
-    ///     .unwrap();
-    /// ```
-    pub fn doesnt_print<O: Into<String>>(mut self, output: O) -> Self {
-        self.expect_output.push(OutputAssertion {
-            expect: output.into(),
-            fuzzy: true,
-            expected_result: false,
-            kind: OutputKind::StdOut,
-        });
-        self
-    }
-
-    /// Expect the command to output to not be **exactly** this `output`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// extern crate assert_cli;
-    ///
-    /// assert_cli::Assert::command(&["echo", "42"])
-    ///     .doesnt_print_exactly("73")
-    ///     .execute()
-    ///     .unwrap();
-    /// ```
-    pub fn doesnt_print_exactly<O: Into<String>>(mut self, output: O) -> Self {
-        self.expect_output.push(OutputAssertion {
-            expect: output.into(),
-            fuzzy: false,
-            expected_result: false,
-            kind: OutputKind::StdOut,
-        });
-        self
-    }
-
-    /// Expect the command's stderr output to not **contain** `output`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// extern crate assert_cli;
-    ///
-    /// assert_cli::Assert::command(&["cat", "non-existing-file"])
-    ///     .fails()
-    ///     .and()
-    ///     .doesnt_print_error("content")
-    ///     .execute()
-    ///     .unwrap();
-    /// ```
-    pub fn doesnt_print_error<O: Into<String>>(mut self, output: O) -> Self {
-        self.expect_output.push(OutputAssertion {
-            expect: output.into(),
-            fuzzy: true,
-            expected_result: false,
-            kind: OutputKind::StdErr,
-        });
-        self
-    }
-
-    /// Expect the command to output to not be **exactly** this `output` to stderr.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// extern crate assert_cli;
-    ///
-    /// assert_cli::Assert::command(&["cat", "non-existing-file"])
-    ///     .fails_with(1)
-    ///     .and()
-    ///     .doesnt_print_error_exactly("content")
-    ///     .execute()
-    ///     .unwrap();
-    /// ```
-    pub fn doesnt_print_error_exactly<O: Into<String>>(mut self, output: O) -> Self {
-        self.expect_output.push(OutputAssertion {
-            expect: output.into(),
-            fuzzy: false,
-            expected_result: false,
-            kind: OutputKind::StdErr,
-        });
-        self
+        }
     }
 
     /// Execute the command and check the assertions.
@@ -364,7 +224,7 @@ impl Assert {
     /// extern crate assert_cli;
     ///
     /// let test = assert_cli::Assert::command(&["echo", "42"])
-    ///     .prints("42")
+    ///     .stdout().contains("42")
     ///     .execute();
     /// assert!(test.is_ok());
     /// ```
@@ -420,5 +280,102 @@ impl Assert {
         if let Err(err) = self.execute() {
             panic!("{}", err);
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct OutputAssertionBuilder {
+    pub assertion: Assert,
+    pub kind: OutputKind,
+    pub expected_result: bool,
+}
+
+impl OutputAssertionBuilder {
+    /// Negate the assertion predicate
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    ///
+    /// assert_cli::Assert::command(&["echo", "42"])
+    ///     .stdout().not().contains("73")
+    ///     .unwrap();
+    /// ```
+    pub fn not(mut self) -> Self {
+        self.expected_result = ! self.expected_result;
+        self
+    }
+
+    /// Expect the command's output to **contain** `output`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    ///
+    /// assert_cli::Assert::command(&["echo", "42"])
+    ///     .stdout().contains("42")
+    ///     .unwrap();
+    /// ```
+    pub fn contains<O: Into<String>>(mut self, output: O) -> Assert {
+        self.assertion.expect_output.push(OutputAssertion {
+            expect: output.into(),
+            fuzzy: true,
+            expected_result: self.expected_result,
+            kind: self.kind,
+        });
+        self.assertion
+    }
+
+    /// Expect the command to output **exactly** this `output`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    ///
+    /// assert_cli::Assert::command(&["echo", "42"])
+    ///     .stdout().is("42")
+    ///     .unwrap();
+    /// ```
+    pub fn is<O: Into<String>>(mut self, output: O) -> Assert {
+        self.assertion.expect_output.push(OutputAssertion {
+            expect: output.into(),
+            fuzzy: false,
+            expected_result: self.expected_result,
+            kind: self.kind,
+        });
+        self.assertion
+    }
+
+    /// Expect the command's output to not **contain** `output`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    ///
+    /// assert_cli::Assert::command(&["echo", "42"])
+    ///     .stdout().doesnt_contain("73")
+    ///     .unwrap();
+    /// ```
+    pub fn doesnt_contain<O: Into<String>>(self, output: O) -> Assert {
+        self.not().contains(output)
+    }
+
+    /// Expect the command to output to not be **exactly** this `output`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    ///
+    /// assert_cli::Assert::command(&["echo", "42"])
+    ///     .stdout().isnt("73")
+    ///     .unwrap();
+    /// ```
+    pub fn isnt<O: Into<String>>(self, output: O) -> Assert {
+        self.not().is(output)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,8 +67,6 @@
 //! # fn main() {
 //! assert_cmd!(cat "non-existing-file")
 //!     .fails()
-//!     .and()
-//!     .stderr().contains("non-existing-file")
 //!     .unwrap();
 //! # }
 //! ```
@@ -78,9 +76,24 @@
 //! - Use `fails_with` to assert a specific exit status.
 //! - There is also a `succeeds` method, but this is already the implicit default
 //!   and can usually be omitted.
-//! - We can inspect the output of **stderr** with `stderr().contains` and `stderr().is`.
 //! - The `and` method has no effect, other than to make everything more readable.
 //!   Feel free to use it. :-)
+//!
+//! ## stdout / stderr
+//!
+//! You can add assertions on the content of **stdout** and **stderr**.  They
+//! can be mixed together or even multiple of one stream can be used.
+//!
+//! ```rust
+//! # #[macro_use] extern crate assert_cli;
+//! # fn main() {
+//! assert_cmd!(echo "Hello world! The ansswer is 42.")
+//!     .stdout().contains("Hello world")
+//!     .stdout().contains("42")
+//!     .stderr().is("")
+//!     .unwrap();
+//! # }
+//! ```
 //!
 //! ## Assert CLI Crates
 //!
@@ -119,3 +132,4 @@ mod diff;
 
 mod assert;
 pub use assert::Assert;
+pub use assert::OutputAssertionBuilder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! ```rust
 //! assert_cli::Assert::command(&["echo", "42"])
-//!     .prints("42")
+//!     .stdout().contains("42")
 //!     .unwrap();
 //! ```
 //!
@@ -26,7 +26,7 @@
 //!
 //! ```rust,should_panic
 //! assert_cli::Assert::command(&["echo", "42"])
-//!     .prints_exactly("1337")
+//!     .stdout().is("1337")
 //!     .unwrap();
 //! ```
 //!
@@ -45,7 +45,7 @@
 //! ```rust
 //! # #[macro_use] extern crate assert_cli;
 //! # fn main() {
-//! assert_cmd!(echo "42").prints("42").unwrap();
+//! assert_cmd!(echo "42").stdout().contains("42").unwrap();
 //! # }
 //! ```
 //!
@@ -68,7 +68,7 @@
 //! assert_cmd!(cat "non-existing-file")
 //!     .fails()
 //!     .and()
-//!     .prints_error("non-existing-file")
+//!     .stderr().contains("non-existing-file")
 //!     .unwrap();
 //! # }
 //! ```
@@ -78,7 +78,7 @@
 //! - Use `fails_with` to assert a specific exit status.
 //! - There is also a `succeeds` method, but this is already the implicit default
 //!   and can usually be omitted.
-//! - We can inspect the output of **stderr** with `prints_error` and `prints_error_exactly`.
+//! - We can inspect the output of **stderr** with `stderr().contains` and `stderr().is`.
 //! - The `and` method has no effect, other than to make everything more readable.
 //!   Feel free to use it. :-)
 //!
@@ -97,7 +97,7 @@
 //! ```rust
 //! # #[macro_use] extern crate assert_cli;
 //! # fn main() {
-//! let x = assert_cmd!(echo "1337").prints_exactly("42").execute();
+//! let x = assert_cmd!(echo "1337").stdout().is("42").execute();
 //! assert!(x.is_err());
 //! # }
 //! ```

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -22,7 +22,7 @@ use serde_json;
 /// # fn main() {
 /// assert_cmd!(echo "Launch sequence initiated.\nNo errors whatsoever!\n")
 ///     .succeeds()
-///     .prints("No errors whatsoever")
+///     .stdout().contains("No errors whatsoever")
 ///     .unwrap();
 /// # }
 /// ```


### PR DESCRIPTION
Reusing output assertions makes it easier to add new ones in the future.

I feel the new naming scheme this provides makes intent of the API clearer as well (`stdout().contains` vs `prints`).

This is done by creating an `OutputAssertionBuilder` that `Assertion` delegates to for creating output assertions, passing in an enum of which stream to read from.   This unfortunately meant dropping the cool type tricks that were introduced in #24.  This also required merging the storage of stdout/stderr assertions.  To accommodate this, output assertions are now appended which might be useful on its own.