### PR TITLE
Increase context on failures

### DIFF
--- a/src/assert.rs
+++ b/src/assert.rs
@@ -241,19 +241,27 @@ impl Assert {
 
         if let Some(expect_success) = self.expect_success {
             if expect_success != output.status.success() {
+                let out = String::from_utf8_lossy(&output.stdout).to_string();
+                let err = String::from_utf8_lossy(&output.stderr).to_string();
                 bail!(ErrorKind::StatusMismatch(
                     self.cmd.clone(),
                     expect_success,
+                    out,
+                    err,
                 ));
             }
         }
 
         if self.expect_exit_code.is_some() &&
             self.expect_exit_code != output.status.code() {
+            let out = String::from_utf8_lossy(&output.stdout).to_string();
+            let err = String::from_utf8_lossy(&output.stderr).to_string();
             bail!(ErrorKind::ExitCodeMismatch(
                 self.cmd.clone(),
                 self.expect_exit_code,
                 output.status.code(),
+                out,
+                err,
             ));
         }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,24 +6,28 @@ error_chain! {
         Fmt(::std::fmt::Error);
     }
     errors {
-        StatusMismatch(cmd: Vec<String>, expected: bool) {
+        StatusMismatch(cmd: Vec<String>, expected: bool, out: String, err: String) {
             description("Wrong status")
             display(
-                "{}: (command `{}` expected to {}) (command {})",
+                "{}: (command `{}` expected to {})\nstatus={}\nstdout=```{}```\nstderr=```{}```",
                 ERROR_PREFIX,
                 cmd.join(" "),
                 expected = if *expected { "succeed" } else { "fail" },
                 got = if *expected { "failed" } else { "succeeded" },
+                out = out,
+                err = err,
             )
         }
-        ExitCodeMismatch(cmd: Vec<String>, expected: Option<i32>, got: Option<i32>) {
+        ExitCodeMismatch(cmd: Vec<String>, expected: Option<i32>, got: Option<i32>, out: String, err: String) {
             description("Wrong exit code")
             display(
-                "{}: (exit code of `{}` expected to be `{:?}`) (exit code was: `{:?}`)",
+                "{}: (exit code of `{}` expected to be `{:?}`)\nexit code=`{:?}`\nstdout=```{}```\nstderr=```{}```",
                 ERROR_PREFIX,
                 cmd.join(" "),
                 expected,
                 got,
+                out,
+                err,
             )
         }
         StdoutMismatch(cmd: Vec<String>, output_err: ::output::Error) {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,18 +30,11 @@ error_chain! {
                 err,
             )
         }
-        StdoutMismatch(cmd: Vec<String>, output_err: ::output::Error) {
+        OutputMismatch(cmd: Vec<String>, output_err: ::output::Error, kind: ::output::OutputKind) {
             description("Output was not as expected")
             display(
-                "{}: `{}` stdout mismatch: `{}`)",
-                ERROR_PREFIX, cmd.join(" "), output_err,
-            )
-        }
-        StderrMismatch(cmd: Vec<String>, output_err: ::output::Error) {
-            description("Error output was not as expected")
-            display(
-                "{}: `{}` stderr mismatch: `{}`)",
-                ERROR_PREFIX, cmd.join(" "), output_err,
+                "{}: `{}` {:?} mismatch: {}",
+                ERROR_PREFIX, cmd.join(" "), kind, output_err,
             )
         }
 


### PR DESCRIPTION
- Show stdout/stderr on exit code failures
- Show expected/got strings for output assertions

This also includes a minor refactor to simplify `output.rs`.