### PR TITLE
 fix: Remove unrelated output in main_binary 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ categories = ["development-tools::testing"]
 keywords = ["cli", "testing", "assert"]
 build = "build.rs"
 
+[[bin]]
+name = "assert_fixture"
+
 [dependencies]
 colored = "1.5"
 difference = "1.0"

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -1,4 +1,5 @@
 use environment::Environment;
+use error_chain::ChainedError;
 use errors::*;
 use output::{OutputAssertion, OutputKind};
 use std::default;
@@ -332,7 +333,9 @@ impl Assert {
             None => command,
         };
 
-        let mut spawned = command.spawn()?;
+        let mut spawned = command
+            .spawn()
+            .chain_err(|| ErrorKind::SpawnFailed(self.cmd.clone()))?;
 
         if let Some(ref contents) = self.stdin_contents {
             spawned
@@ -389,7 +392,7 @@ impl Assert {
     /// ```
     pub fn unwrap(self) {
         if let Err(err) = self.execute() {
-            panic!("{}", err);
+            panic!("{}", err.display_chain());
         }
     }
 }

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -26,7 +26,7 @@ impl default::Default for Assert {
     /// Defaults to asserting _successful_ execution.
     fn default() -> Self {
         Assert {
-            cmd: vec!["cargo", "run", "--"]
+            cmd: vec!["cargo", "run", "--quiet", "--"]
                 .into_iter()
                 .map(String::from)
                 .collect(),
@@ -53,7 +53,7 @@ impl Assert {
     /// Defaults to asserting _successful_ execution.
     pub fn cargo_binary(name: &str) -> Self {
         Assert {
-            cmd: vec!["cargo", "run", "--bin", name, "--"]
+            cmd: vec!["cargo", "run", "--quiet", "--bin", name, "--"]
                 .into_iter()
                 .map(String::from)
                 .collect(),

--- a/src/bin/assert_fixture.rs
+++ b/src/bin/assert_fixture.rs
@@ -1,0 +1,31 @@
+#[macro_use]
+extern crate error_chain;
+
+use std::env;
+use std::process;
+
+error_chain! {
+    foreign_links {
+        Env(env::VarError);
+        ParseInt(std::num::ParseIntError);
+    }
+}
+
+fn run() -> Result<()> {
+    if let Ok(text) = env::var("stdout") {
+        println!("{}", text);
+    }
+    if let Ok(text) = env::var("stderr") {
+        eprintln!("{}", text);
+    }
+
+    let code = env::var("exit")
+        .ok()
+        .map(|v| v.parse::<i32>())
+        .map_or(Ok(None), |r| r.map(Some))
+        .chain_err(|| "Invalid exit code")?
+        .unwrap_or(0);
+    process::exit(code);
+}
+
+quick_main!(run);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,6 +6,14 @@ error_chain! {
         Fmt(::std::fmt::Error);
     }
     errors {
+        SpawnFailed(cmd: Vec<String>) {
+            description("Spawn failed")
+            display(
+                "{}: (command `{}` failed to run)",
+                ERROR_PREFIX,
+                cmd.join(" "),
+            )
+        }
         StatusMismatch(cmd: Vec<String>, expected: bool, out: String, err: String) {
             description("Wrong status")
             display(

--- a/tests/cargo.rs
+++ b/tests/cargo.rs
@@ -5,7 +5,9 @@ fn main_binary() {
     assert_cli::Assert::main_binary()
         .with_env(assert_cli::Environment::inherit().insert("stdout", "42"))
         .stdout()
-        .contains("42")
+        .is("42")
+        .stderr()
+        .is("")
         .unwrap();
 }
 
@@ -14,6 +16,8 @@ fn cargo_binary() {
     assert_cli::Assert::cargo_binary("assert_fixture")
         .with_env(assert_cli::Environment::inherit().insert("stdout", "42"))
         .stdout()
-        .contains("42")
+        .is("42")
+        .stderr()
+        .is("")
         .unwrap();
 }

--- a/tests/cargo.rs
+++ b/tests/cargo.rs
@@ -1,0 +1,19 @@
+extern crate assert_cli;
+
+#[test]
+fn main_binary() {
+    assert_cli::Assert::main_binary()
+        .with_env(assert_cli::Environment::inherit().insert("stdout", "42"))
+        .stdout()
+        .contains("42")
+        .unwrap();
+}
+
+#[test]
+fn cargo_binary() {
+    assert_cli::Assert::cargo_binary("assert_fixture")
+        .with_env(assert_cli::Environment::inherit().insert("stdout", "42"))
+        .stdout()
+        .contains("42")
+        .unwrap();
+}


### PR DESCRIPTION
To help in validating this, tests have been added for `main_binary` and `cargo_binary`. 

Fixed #45 