### PR TITLE
No unnecessary rebuilds on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ before_script:
   export PATH=$HOME/.local/bin:$PATH
 script:
 - |
-  travis-cargo build &&
-  travis-cargo clean &&
   travis-cargo test &&
   travis-cargo bench
 notifications:


### PR DESCRIPTION
Why would we need to build, clean, build again? I guess either the
author of this commit or of the author of 1e04c940 was drunk or
something.