### PR TITLE
Add Assert::ignore_status() for ignoring the command status

### DIFF
--- a/src/assert.rs
+++ b/src/assert.rs
@@ -238,6 +238,25 @@ impl Assert {
         self
     }
 
+    /// Do not care whether the command exits successfully or if it fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    ///
+    /// assert_cli::Assert::command(&["cat", "non-existing-file"])
+    ///     .ignore_status()
+    ///     .and()
+    ///     .stderr().is("cat: non-existing-file: No such file or directory")
+    ///     .unwrap();
+    /// ```
+    pub fn ignore_status(mut self) -> Self {
+        self.expect_exit_code = None;
+        self.expect_success = None;
+        self
+    }
+
     /// Create an assertion for stdout's contents
     ///
     /// # Examples

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -240,6 +240,9 @@ impl Assert {
 
     /// Do not care whether the command exits successfully or if it fails.
     ///
+    /// This function removes any assertions that were already set, including
+    /// any expected exit code that was set with [`fails_with`].
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -251,6 +254,8 @@ impl Assert {
     ///     .stderr().is("cat: non-existing-file: No such file or directory")
     ///     .unwrap();
     /// ```
+    ///
+    /// [`fails_with`]: #method.fails_with
     pub fn ignore_status(mut self) -> Self {
         self.expect_exit_code = None;
         self.expect_success = None;


### PR DESCRIPTION
Implements `Assert::ignore_status()`, which can be used to ignore whether a command exited successfully.

Fixes #23.