### PR TITLE
Update to difference v2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "assert_fixture"
 
 [dependencies]
 colored = "1.5"
-difference = "1.0"
+difference = "2.0"
 error-chain = "0.11"
 serde_json = "1.0"
 environment = "0.1"

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -55,7 +55,7 @@ mod tests {
         println!("{}", render(&diff).unwrap());
         assert_eq!(
             render(&diff).unwrap(),
-            " \n\u{1b}[31m-lol\u{1b}[0m\n\u{1b}[32m+\u{1b}[0m\u{1b}[7;32myay\u{1b}[0m \n"
+            "\u{1b}[31m-lol\u{1b}[0m\n\u{1b}[32m+\u{1b}[0m\u{1b}[7;32myay\u{1b}[0m \n"
         )
     }
 


### PR DESCRIPTION
This updates the difference dependency to version 2, which introduces a
slightly rewritten difference algorithm and was failing tests for some
crates (including this one). Hence the major version bump.

The failing test in this case was just some white space being prepended
to the output (presumably because difference added an empty string to the
beginning of its output before), so that looks more like a fix to me.

<!--
Thank you for taking the time to contribute to this project!

To ease reviewing your changes and making sure we don't forget anything,  please
take a minute to check the following (remove lines that don't apply), and
replace this text with a description of what this PR does. Bonus points for
linking to issues! :)
-->

- [x] `cargo test` succeeds