### PR TITLE
Refactor output

### DIFF
--- a/src/assert.rs
+++ b/src/assert.rs
@@ -1,7 +1,7 @@
 use environment::Environment;
 use error_chain::ChainedError;
 use errors::*;
-use output::{OutputAssertion, OutputKind};
+use output::{Output, OutputKind, OutputPredicate};
 use std::default;
 use std::ffi::{OsStr, OsString};
 use std::io::Write;
@@ -18,7 +18,7 @@ pub struct Assert {
     current_dir: Option<PathBuf>,
     expect_success: Option<bool>,
     expect_exit_code: Option<i32>,
-    expect_output: Vec<OutputAssertion>,
+    expect_output: Vec<OutputPredicate>,
     stdin_contents: Option<String>,
 }
 
@@ -289,7 +289,6 @@ impl Assert {
         OutputAssertionBuilder {
             assertion: self,
             kind: OutputKind::StdOut,
-            expected_result: true,
         }
     }
 
@@ -310,7 +309,6 @@ impl Assert {
         OutputAssertionBuilder {
             assertion: self,
             kind: OutputKind::StdErr,
-            expected_result: true,
         }
     }
 
@@ -327,10 +325,10 @@ impl Assert {
     /// assert!(test.is_ok());
     /// ```
     pub fn execute(self) -> Result<()> {
-        let cmd = &self.cmd[0];
+        let bin = &self.cmd[0];
 
         let args: Vec<_> = self.cmd.iter().skip(1).collect();
-        let mut command = Command::new(cmd);
+        let mut command = Command::new(bin);
         let command = command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -361,30 +359,23 @@ impl Assert {
             if expect_success != output.status.success() {
                 let out = String::from_utf8_lossy(&output.stdout).to_string();
                 let err = String::from_utf8_lossy(&output.stderr).to_string();
-                bail!(ErrorKind::StatusMismatch(
-                    self.cmd.clone(),
-                    expect_success,
-                    out,
-                    err,
-                ));
+                let err: Error = ErrorKind::StatusMismatch(expect_success, out, err).into();
+                bail!(err.chain_err(|| ErrorKind::AssertionFailed(self.cmd.clone())));
             }
         }
 
         if self.expect_exit_code.is_some() && self.expect_exit_code != output.status.code() {
             let out = String::from_utf8_lossy(&output.stdout).to_string();
             let err = String::from_utf8_lossy(&output.stderr).to_string();
-            bail!(ErrorKind::ExitCodeMismatch(
-                self.cmd.clone(),
-                self.expect_exit_code,
-                output.status.code(),
-                out,
-                err,
-            ));
+            let err: Error =
+                ErrorKind::ExitCodeMismatch(self.expect_exit_code, output.status.code(), out, err)
+                    .into();
+            bail!(err.chain_err(|| ErrorKind::AssertionFailed(self.cmd.clone())));
         }
 
         self.expect_output
             .iter()
-            .map(|a| a.execute(&output, &self.cmd))
+            .map(|a| a.verify_output(&output).chain_err(|| ErrorKind::AssertionFailed(self.cmd.clone())))
             .collect::<Result<Vec<()>>>()?;
 
         Ok(())
@@ -414,28 +405,9 @@ impl Assert {
 pub struct OutputAssertionBuilder {
     assertion: Assert,
     kind: OutputKind,
-    expected_result: bool,
 }
 
 impl OutputAssertionBuilder {
-    /// Negate the assertion predicate
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// extern crate assert_cli;
-    ///
-    /// assert_cli::Assert::command(&["echo", "42"])
-    ///     .stdout().not().contains("73")
-    ///     .unwrap();
-    /// ```
-    // No clippy, we don't want to implement std::ops::Not :)
-    #[cfg_attr(feature = "cargo-clippy", allow(should_implement_trait))]
-    pub fn not(mut self) -> Self {
-        self.expected_result = !self.expected_result;
-        self
-    }
-
     /// Expect the command's output to **contain** `output`.
     ///
     /// # Examples
@@ -448,12 +420,8 @@ impl OutputAssertionBuilder {
     ///     .unwrap();
     /// ```
     pub fn contains<O: Into<String>>(mut self, output: O) -> Assert {
-        self.assertion.expect_output.push(OutputAssertion {
-            expect: output.into(),
-            fuzzy: true,
-            expected_result: self.expected_result,
-            kind: self.kind,
-        });
+        let pred = OutputPredicate::new(self.kind, Output::contains(output));
+        self.assertion.expect_output.push(pred);
         self.assertion
     }
 
@@ -469,12 +437,8 @@ impl OutputAssertionBuilder {
     ///     .unwrap();
     /// ```
     pub fn is<O: Into<String>>(mut self, output: O) -> Assert {
-        self.assertion.expect_output.push(OutputAssertion {
-            expect: output.into(),
-            fuzzy: false,
-            expected_result: self.expected_result,
-            kind: self.kind,
-        });
+        let pred = OutputPredicate::new(self.kind, Output::is(output));
+        self.assertion.expect_output.push(pred);
         self.assertion
     }
 
@@ -489,8 +453,10 @@ impl OutputAssertionBuilder {
     ///     .stdout().doesnt_contain("73")
     ///     .unwrap();
     /// ```
-    pub fn doesnt_contain<O: Into<String>>(self, output: O) -> Assert {
-        self.not().contains(output)
+    pub fn doesnt_contain<O: Into<String>>(mut self, output: O) -> Assert {
+        let pred = OutputPredicate::new(self.kind, Output::doesnt_contain(output));
+        self.assertion.expect_output.push(pred);
+        self.assertion
     }
 
     /// Expect the command to output to not be **exactly** this `output`.
@@ -504,8 +470,10 @@ impl OutputAssertionBuilder {
     ///     .stdout().isnt("73")
     ///     .unwrap();
     /// ```
-    pub fn isnt<O: Into<String>>(self, output: O) -> Assert {
-        self.not().is(output)
+    pub fn isnt<O: Into<String>>(mut self, output: O) -> Assert {
+        let pred = OutputPredicate::new(self.kind, Output::isnt(output));
+        self.assertion.expect_output.push(pred);
+        self.assertion
     }
 }
 
@@ -522,7 +490,7 @@ mod test {
     fn take_ownership() {
         let x = Environment::inherit();
 
-        command().with_env(x.clone()).with_env(&x).with_env(x);
+        command().with_env(x.clone()).with_env(&x).with_env(x).unwrap();
     }
 
     #[test]
@@ -564,8 +532,7 @@ mod test {
         command()
             .with_env(y)
             .stdout()
-            .not()
-            .contains("key=value")
+            .doesnt_contain("key=value")
             .execute()
             .unwrap();
     }

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -19,7 +19,7 @@ pub struct Assert {
     expect_success: Option<bool>,
     expect_exit_code: Option<i32>,
     expect_output: Vec<OutputPredicate>,
-    stdin_contents: Option<String>,
+    stdin_contents: Option<Vec<u8>>,
 }
 
 impl default::Default for Assert {
@@ -118,8 +118,8 @@ impl Assert {
     ///     .stdout().contains("42")
     ///     .unwrap();
     /// ```
-    pub fn stdin(mut self, contents: &str) -> Self {
-        self.stdin_contents = Some(String::from(contents));
+    pub fn stdin<S: Into<Vec<u8>>>(mut self, contents: S) -> Self {
+        self.stdin_contents = Some(contents.into());
         self
     }
 
@@ -351,7 +351,7 @@ impl Assert {
                 .stdin
                 .as_mut()
                 .expect("Couldn't get mut ref to command stdin")
-                .write_all(contents.as_bytes())?;
+                .write_all(contents)?;
         }
         let output = spawned.wait_with_output()?;
 

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -1,13 +1,15 @@
-use environment::Environment;
-use error_chain::ChainedError;
-use errors::*;
-use output::{Output, OutputKind, OutputPredicate};
 use std::default;
 use std::ffi::{OsStr, OsString};
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::vec::Vec;
+
+use environment::Environment;
+use error_chain::ChainedError;
+
+use errors::*;
+use output::{Content, Output, OutputKind, OutputPredicate};
 
 /// Assertions for a specific command.
 #[derive(Debug)]
@@ -375,7 +377,7 @@ impl Assert {
 
         self.expect_output
             .iter()
-            .map(|a| a.verify_output(&output).chain_err(|| ErrorKind::AssertionFailed(self.cmd.clone())))
+            .map(|a| a.verify(&output).chain_err(|| ErrorKind::AssertionFailed(self.cmd.clone())))
             .collect::<Result<Vec<()>>>()?;
 
         Ok(())
@@ -419,7 +421,7 @@ impl OutputAssertionBuilder {
     ///     .stdout().contains("42")
     ///     .unwrap();
     /// ```
-    pub fn contains<O: Into<String>>(mut self, output: O) -> Assert {
+    pub fn contains<O: Into<Content>>(mut self, output: O) -> Assert {
         let pred = OutputPredicate::new(self.kind, Output::contains(output));
         self.assertion.expect_output.push(pred);
         self.assertion
@@ -436,7 +438,7 @@ impl OutputAssertionBuilder {
     ///     .stdout().is("42")
     ///     .unwrap();
     /// ```
-    pub fn is<O: Into<String>>(mut self, output: O) -> Assert {
+    pub fn is<O: Into<Content>>(mut self, output: O) -> Assert {
         let pred = OutputPredicate::new(self.kind, Output::is(output));
         self.assertion.expect_output.push(pred);
         self.assertion
@@ -453,7 +455,7 @@ impl OutputAssertionBuilder {
     ///     .stdout().doesnt_contain("73")
     ///     .unwrap();
     /// ```
-    pub fn doesnt_contain<O: Into<String>>(mut self, output: O) -> Assert {
+    pub fn doesnt_contain<O: Into<Content>>(mut self, output: O) -> Assert {
         let pred = OutputPredicate::new(self.kind, Output::doesnt_contain(output));
         self.assertion.expect_output.push(pred);
         self.assertion
@@ -470,7 +472,7 @@ impl OutputAssertionBuilder {
     ///     .stdout().isnt("73")
     ///     .unwrap();
     /// ```
-    pub fn isnt<O: Into<String>>(mut self, output: O) -> Assert {
+    pub fn isnt<O: Into<Content>>(mut self, output: O) -> Assert {
         let pred = OutputPredicate::new(self.kind, Output::isnt(output));
         self.assertion.expect_output.push(pred);
         self.assertion

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -475,6 +475,26 @@ impl OutputAssertionBuilder {
         self.assertion.expect_output.push(pred);
         self.assertion
     }
+
+    /// Expect the command output to satisfy the given predicate.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    ///
+    /// assert_cli::Assert::command(&["echo", "-n", "42"])
+    ///     .stdout().satisfies(|x| x.len() == 2, "bad length")
+    ///     .unwrap();
+    /// ```
+    pub fn satisfies<F, M>(mut self, pred: F, msg: M) -> Assert
+        where F: 'static + Fn(&str) -> bool,
+              M: Into<String>
+    {
+        let pred = OutputPredicate::new(self.kind, Output::satisfies(pred, msg));
+        self.assertion.expect_output.push(pred);
+        self.assertion
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,11 +129,10 @@ mod errors;
 mod macros;
 pub use macros::flatten_escaped_string;
 
+mod assert;
+mod diff;
 mod output;
 
-mod diff;
-
-mod assert;
 pub use assert::Assert;
 pub use assert::OutputAssertionBuilder;
 /// Environment is a re-export of the Environment crate

--- a/src/output.rs
+++ b/src/output.rs
@@ -2,35 +2,17 @@ use self::errors::*;
 pub use self::errors::{Error, ErrorKind};
 use diff;
 use difference::Changeset;
-use std::ffi::OsString;
-use std::process::Output;
+use std::process;
 
-#[derive(Debug, Clone)]
-pub struct OutputAssertion {
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IsPredicate {
     pub expect: String,
-    pub fuzzy: bool,
     pub expected_result: bool,
-    pub kind: OutputKind,
 }
 
-impl OutputAssertion {
-    fn matches_fuzzy(&self, got: &str) -> Result<()> {
-        let result = got.contains(&self.expect);
-        if result != self.expected_result {
-            if self.expected_result {
-                bail!(ErrorKind::OutputDoesntContain(
-                    self.expect.clone(),
-                    got.into()
-                ));
-            } else {
-                bail!(ErrorKind::OutputContains(self.expect.clone(), got.into()));
-            }
-        }
-
-        Ok(())
-    }
-
-    fn matches_exact(&self, got: &str) -> Result<()> {
+impl IsPredicate {
+    pub fn verify_str(&self, got: &str) -> Result<()> {
         let differences = Changeset::new(self.expect.trim(), got.trim(), "\n");
         let result = differences.distance == 0;
 
@@ -49,20 +31,140 @@ impl OutputAssertion {
 
         Ok(())
     }
+}
 
-    pub fn execute(&self, output: &Output, cmd: &[OsString]) -> super::errors::Result<()> {
-        let observed = String::from_utf8_lossy(self.kind.select(output));
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ContainsPredicate {
+    pub expect: String,
+    pub expected_result: bool,
+}
 
-        let result = if self.fuzzy {
-            self.matches_fuzzy(&observed)
-        } else {
-            self.matches_exact(&observed)
-        };
-        result.map_err(|e| {
-            super::errors::ErrorKind::OutputMismatch(cmd.to_vec(), e, self.kind)
-        })?;
+impl ContainsPredicate {
+    pub fn verify_str(&self, got: &str) -> Result<()> {
+        let result = got.contains(&self.expect);
+        if result != self.expected_result {
+            if self.expected_result {
+                bail!(ErrorKind::OutputDoesntContain(
+                    self.expect.clone(),
+                    got.into()
+                ));
+            } else {
+                bail!(ErrorKind::OutputContains(self.expect.clone(), got.into()));
+            }
+        }
 
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+enum StrPredicate {
+    Is(IsPredicate),
+    Contains(ContainsPredicate),
+}
+
+impl StrPredicate {
+    pub fn verify_str(&self, got: &str) -> Result<()> {
+        match *self {
+            StrPredicate::Is(ref pred) => pred.verify_str(got),
+            StrPredicate::Contains(ref pred) => pred.verify_str(got),
+        }
+    }
+}
+
+/// Assertions for command output.
+#[derive(Debug, Clone)]
+pub struct Output {
+    pred: StrPredicate,
+}
+
+impl Output {
+    /// Expect the command's output to **contain** `output`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    ///
+    /// assert_cli::Assert::command(&["echo"])
+    ///     .with_args(&["42"])
+    ///     .stdout().contains("42")
+    ///     .unwrap();
+    /// ```
+    pub fn contains<O: Into<String>>(output: O) -> Self {
+        let pred = ContainsPredicate {
+            expect: output.into(),
+            expected_result: true,
+        };
+        Self::new(StrPredicate::Contains(pred))
+    }
+
+    /// Expect the command to output **exactly** this `output`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    ///
+    /// assert_cli::Assert::command(&["echo"])
+    ///     .with_args(&["42"])
+    ///     .stdout().is("42")
+    ///     .unwrap();
+    /// ```
+    pub fn is<O: Into<String>>(output: O) -> Self {
+        let pred = IsPredicate {
+            expect: output.into(),
+            expected_result: true,
+        };
+        Self::new(StrPredicate::Is(pred))
+    }
+
+    /// Expect the command's output to not **contain** `output`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    ///
+    /// assert_cli::Assert::command(&["echo"])
+    ///     .with_args(&["42"])
+    ///     .stdout().doesnt_contain("73")
+    ///     .unwrap();
+    /// ```
+    pub fn doesnt_contain<O: Into<String>>(output: O) -> Self {
+        let pred = ContainsPredicate {
+            expect: output.into(),
+            expected_result: false,
+        };
+        Self::new(StrPredicate::Contains(pred))
+    }
+
+    /// Expect the command to output to not be **exactly** this `output`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    ///
+    /// assert_cli::Assert::command(&["echo"])
+    ///     .with_args(&["42"])
+    ///     .stdout().isnt("73")
+    ///     .unwrap();
+    /// ```
+    pub fn isnt<O: Into<String>>(output: O) -> Self {
+        let pred = IsPredicate {
+            expect: output.into(),
+            expected_result: false,
+        };
+        Self::new(StrPredicate::Is(pred))
+    }
+
+    fn new(pred: StrPredicate) -> Self {
+        Self { pred }
+    }
+
+    pub(crate) fn verify_str(&self, got: &str) -> Result<()> {
+        self.pred.verify_str(got)
     }
 }
 
@@ -73,11 +175,38 @@ pub enum OutputKind {
 }
 
 impl OutputKind {
-    pub fn select(self, o: &Output) -> &[u8] {
+    pub fn select(self, o: &process::Output) -> &[u8] {
         match self {
             OutputKind::StdOut => &o.stdout,
             OutputKind::StdErr => &o.stderr,
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OutputPredicate {
+    kind: OutputKind,
+    pred: Output,
+}
+
+impl OutputPredicate {
+    pub fn new(kind: OutputKind, pred: Output) -> Self {
+        Self {
+            kind,
+            pred,
+        }
+    }
+
+    pub(crate) fn verify_str(&self, got: &str) -> Result<()> {
+        let kind = self.kind;
+        self.pred
+            .verify_str(got)
+            .chain_err(|| ErrorKind::OutputMismatch(kind))
+    }
+
+    pub(crate) fn verify_output(&self, got: &process::Output) -> Result<()> {
+        let got = String::from_utf8_lossy(self.kind.select(got));
+        self.verify_str(&got)
     }
 }
 
@@ -102,6 +231,13 @@ mod errors {
             OutputMatches(got: String) {
                 description("Output was not as expected")
                 display("expected to not match\noutput=```{}```", got)
+            }
+            OutputMismatch(kind: super::OutputKind) {
+                description("Output was not as expected")
+                display(
+                    "Unexpected {:?}",
+                    kind
+                )
             }
         }
     }


### PR DESCRIPTION
This PR (mostly) keeps the same API but replaces the guts with those from #74.

Other foundational output predicate functionality is added in to help this serve as a base for further work (like regexes in #85).